### PR TITLE
Update Sentinel/SMAP data version to 2

### DIFF
--- a/tests/testthat/test-extract_smap.R
+++ b/tests/testthat/test-extract_smap.R
@@ -75,26 +75,28 @@ test_that("extraction still works with user specified directories", {
 
 test_that("Sentinel/SMAP integrated products can read properly", {
     skip_on_cran()
-
-    files <- find_smap('SPL2SMAP_S', '2016-06-08', 1)
-    downloads <- download_smap(files, overwrite = FALSE)
+    
+    files <- find_smap('SPL2SMAP_S', '2016-06-08', 2)
+    
+    n_to_use <- 2L # don't use all files, use this many instead
+    downloads <- download_smap(files[1:n_to_use, ])
     r <- extract_smap(downloads,
                        '/Soil_Moisture_Retrieval_Data_3km/soil_moisture_3km')
 
     expect_that(r, is_a('RasterBrick'))
-    expect_identical(raster::nlayers(r), 3L)
+    expect_identical(raster::nlayers(r), n_to_use)
 })
 
 
 test_that("Sentinel/SMAP cannot be extracted with other data types", {
     skip_on_cran()
 
-    files <- find_smap('SPL2SMAP_S', '2016-06-08', 1)
+    files <- find_smap('SPL2SMAP_S', '2016-06-08', 2)
     other_files <- find_smap(id = "SPL3SMP",
                              date = "2015-10-01",
                              version = 4)
-    mixed_files <- rbind(files, other_files)
-    downloads <- download_smap(mixed_files, overwrite = FALSE)
+    mixed_files <- rbind(files[1, ], other_files)
+    downloads <- download_smap(mixed_files)
 
     # extracting two files should give a raster stack with two layers
     to_extract <- '/Soil_Moisture_Retrieval_Data_3km/soil_moisture_3km'


### PR DESCRIPTION
The version 1 Sentinel/SMAP data are no longer available, which caused the unit tests to fail. This PR updates to version 2.